### PR TITLE
config: set CORS allowed origin to todo.test:5175

### DIFF
--- a/src/todo-list/config/cors.php
+++ b/src/todo-list/config/cors.php
@@ -19,7 +19,7 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => ['*'],
+    'allowed_origins' => ['http://todo.test:5175'],
 
     'allowed_origins_patterns' => [],
 


### PR DESCRIPTION
Allow cross-origin requests from Vue dev server and enable credentials

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated CORS configuration to restrict access to a specific origin, enhancing security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->